### PR TITLE
Adding the `__concat` metamethod for easy string concatenation

### DIFF
--- a/bint.lua
+++ b/bint.lua
@@ -1725,6 +1725,12 @@ function bint:__tostring()
   return self:tobase(10)
 end
 
+--- Convert a bint to a string when concatenating it to an other string.
+-- @see bint.tostring
+function bint.__concat(a, b)
+  return tostring(a) .. tostring(b)
+end
+
 -- Allow creating bints by calling bint itself
 setmetatable(bint, {
   __call = function(_, x)

--- a/tests.lua
+++ b/tests.lua
@@ -105,6 +105,10 @@ local function test(bits, wordbits)
     assert(bint.frombase('AAAAAAAAAAAAAAAAAAA') == nil)
     assert(bint.frombase('AAAAAAAAAAAAAAAAAAA_') == nil)
 
+    assert(bint(9592924) .. '_MyString' == '9592924_MyString')
+    assert('MyString_' .. bint(9592924) == 'MyString_9592924')
+    assert('MyString_' .. bint(9592924) .. "_MyString" == 'MyString_9592924_MyString')
+    
     assert(bint.fromstring(1) == nil)
     assert(bint.eq(bint.fromstring('0xff'), 0xff))
     assert(bint.eq(bint.fromstring('+0xff'), 0xff))


### PR DESCRIPTION
Adding the `__concat` metamethod for easy string concatenation, using the already-present `__tostring` metamethod.